### PR TITLE
Reverted to React due to rendering bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4619,7 +4619,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4984,7 +4985,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5032,6 +5034,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5070,11 +5073,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -5781,14 +5786,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
-    },
-    "immutability-helper": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.8.1.tgz",
-      "integrity": "sha512-8AVB5EUpRBUdXqfe4cFsFECsOIZ9hX/Arl8B8S9/tmwpYv3UWvOsXUPOjkuZIMaVxfSWkxCzkng1rjmEoSWrxQ==",
-      "requires": {
-        "invariant": "^2.2.0"
-      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -9668,43 +9665,6 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
-    "preact": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.3.1.tgz",
-      "integrity": "sha512-s8H1Y8O9e+mOBo3UP1jvWqArPmjCba2lrrGLlq/0kN1XuIINUbYtf97iiXKxCuG3eYwmppPKnyW2DBrNj/TuTg=="
-    },
-    "preact-compat": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.18.4.tgz",
-      "integrity": "sha512-aR5CvCIDerE2Y201ERVkWQdTAQKhKGNYujEk4tbyfQDInFTrnCCa3KCeGtULZrwy0PNRBjdQa2/Za7qv7ALNFg==",
-      "requires": {
-        "immutability-helper": "^2.7.1",
-        "preact-render-to-string": "^3.8.2",
-        "preact-transition-group": "^1.1.1",
-        "prop-types": "^15.6.2",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      }
-    },
-    "preact-render-to-string": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz",
-      "integrity": "sha512-przuZPajiurStGgxMoJP0EJeC4xj5CgHv+M7GfF3YxAdhGgEWAkhOSE0xympAFN20uMayntBZpttIZqqLl77fw==",
-      "requires": {
-        "pretty-format": "^3.5.1"
-      },
-      "dependencies": {
-        "pretty-format": {
-          "version": "3.8.0",
-          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-          "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
-        }
-      }
-    },
-    "preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -11078,11 +11038,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
-    },
-    "standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "jsdom": "^13.0.0",
     "lodash.throttle": "^4.1.1",
     "markdown-it": "^8.4.2",
-    "preact": "^8.3.1",
-    "preact-compat": "^3.18.4",
     "prop-types": "^15.6.2",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = (env, argv) => ({
     path: path.resolve(__dirname, 'dist'),
     filename: argv.mode === 'development' ? 'bundle.js' : 'bundle.[hash].js',
   },
-  resolve: {
-    alias: {
-      react: 'preact-compat',
-      'react-dom': 'preact-compat'
-    }
-  },
   optimization: {
     minimizer: [
       new UglifyJsPlugin({


### PR DESCRIPTION
`preact-compat` was throwing some rendering issues where different images to the ones that were meant to appear were in their place. Without a further dig around I'd guess this was to do with how `preact-compat` handles `react-router`. Until I can spend time converting the whole app to `preact` I've switched back to `react` (and the extra 20kb) because I know that, at least, works correctly.